### PR TITLE
Perfwrapper cleanup

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update
-      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 gfortran mpich libomp-dev libomp5 libpapi-dev libjansson-dev libhwloc-dev libczmq-dev check libprotobuf-c-dev protobuf-c-compiler clang
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 gfortran mpich libomp-dev libomp5 libpapi-dev libjansson-dev libhwloc-dev libczmq-dev check libprotobuf-c-dev protobuf-c-compiler clang bats
       - uses: actions/checkout@v2
         with:
           repository: anlsys/libnrm
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update
-      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 gfortran mpich libomp-dev libomp5 libpapi-dev libjansson-dev libhwloc-dev libczmq-dev check libprotobuf-c-dev protobuf-c-compiler clang
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 gfortran mpich libomp-dev libomp5 libpapi-dev libjansson-dev libhwloc-dev libczmq-dev check libprotobuf-c-dev protobuf-c-compiler clang bats
       - uses: actions/checkout@v2
         with:
           repository: anlsys/libnrm
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update
-      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 gfortran mpich libomp-dev libomp5 libpapi-dev libjansson-dev libhwloc-dev libczmq-dev check libprotobuf-c-dev protobuf-c-compiler clang
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 gfortran mpich libomp-dev libomp5 libpapi-dev libjansson-dev libhwloc-dev libczmq-dev check libprotobuf-c-dev protobuf-c-compiler clang bats
       - uses: actions/checkout@v2
         with:
           repository: anlsys/libnrm

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Makefile.in
+.dirstamp
 .libs
 Makefile
 ctests/.deps

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AS_IF([test "x$with_variorum" != "xno"],
        have_variorum=0
       ]
 )
-AM_CONDITIONAL([HAVE_VARIORUM],[$have_variorum])
+AM_CONDITIONAL([HAVE_VARIORUM],[test "$have_variorum" = "1"])
 AC_DEFINE([HAVE_VARIORUM],[$have_variorum], [variorum support])
 AC_SUBST([HAVE_VARIORUM])
 

--- a/nix/libnrm.nix
+++ b/nix/libnrm.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoreconfHook, pkgconfig, zeromq, czmq, jansson, check, protobufc, git, hwloc }:
+{ stdenv, autoreconfHook, pkgconfig, zeromq, czmq, jansson, check, protobufc, hwloc, git, bats }:
 stdenv.mkDerivation {
   src = fetchGit {
     url = "https://github.com/anlsys/libnrm.git";
@@ -7,6 +7,6 @@ stdenv.mkDerivation {
   name = "libnrm";
   prePatch = "echo 0.8.0 > .tarball-version";
   nativeBuildInputs = [ autoreconfHook pkgconfig git ];
-  buildInputs = [ czmq jansson check protobufc hwloc ];
+  buildInputs = [ czmq jansson check protobufc hwloc bats ];
   propagatedBuildInputs = [ zeromq ];
 }

--- a/src/perfwrapper/perfwrapper.c
+++ b/src/perfwrapper/perfwrapper.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
 {
 	int c, err;
 	double freq = 1;
-	char (*EventCodeStrs)[PAPI_MAX_STR_LEN] = NULL;
+	char(*EventCodeStrs)[PAPI_MAX_STR_LEN] = NULL;
 	int EventCodeCnt = 0;
 	int ret = EXIT_FAILURE;
 
@@ -54,12 +54,12 @@ int main(int argc, char **argv)
 	int log_level = NRM_LOG_ERROR;
 
 	const char *usage =
-		"Usage: nrm-perfwrapper [options] [command]\n"
-		"     options:\n"
-		"            -e, --event             PAPI preset event name. Default: PAPI_TOT_INS\n"
-		"            -f, --frequency         Frequency in hz to poll. Default: 10.0\n"
-		"            -v, --verbose           Produce verbose output. Log messages will be displayed to stderr\n"
-		"            -h, --help              Displays this help message\n";
+	        "Usage: nrm-perfwrapper [options] [command]\n"
+	        "     options:\n"
+	        "            -e, --event             PAPI preset event name. Default: PAPI_TOT_INS\n"
+	        "            -f, --frequency         Frequency in hz to poll. Default: 10.0\n"
+	        "            -v, --verbose           Produce verbose output. Log messages will be displayed to stderr\n"
+	        "            -h, --help              Displays this help message\n";
 
 	while (1) {
 		static struct option long_options[] = {
@@ -86,12 +86,15 @@ int main(int argc, char **argv)
 			freq = strtod(optarg, NULL);
 			if (errno != 0 || freq <= 0) {
 				fprintf(stderr,
-					"Error parsing the frequency\n");
+				        "Error parsing the frequency\n");
 				goto cleanup_preinit;
 			}
 			break;
 		case 'e':
-			if ((EventCodeStrs = realloc(EventCodeStrs, (EventCodeCnt + 1) * sizeof(*EventCodeStrs))) == NULL) {
+			if ((EventCodeStrs = realloc(
+			             EventCodeStrs,
+			             (EventCodeCnt + 1) *
+			                     sizeof(*EventCodeStrs))) == NULL) {
 				fprintf(stderr, "realloc failed\n");
 				goto cleanup_preinit;
 			}
@@ -130,7 +133,8 @@ int main(int argc, char **argv)
 	nrm_log_debug("NRM logging initialized.\n");
 
 	// create client
-	if (nrm_client_create(&client, UPSTREAM_URI, PUB_PORT, RPC_PORT) != 0 || client == NULL) {
+	if (nrm_client_create(&client, UPSTREAM_URI, PUB_PORT, RPC_PORT) != 0 ||
+	    client == NULL) {
 		nrm_log_error("Client creation failed\n");
 		goto cleanup_postinit;
 	}
@@ -140,7 +144,7 @@ int main(int argc, char **argv)
 	nrm_log_debug("verbose=%d; freq=%f\n", log_level, freq);
 	nrm_log_debug("Events:\n");
 	for (int i = 0; i < EventCodeCnt; i++)
-	    nrm_log_debug("[%d]=%s\n", i, EventCodeStrs[i]);
+		nrm_log_debug("[%d]=%s\n", i, EventCodeStrs[i]);
 
 	if (optind >= argc) {
 		nrm_log_error("Expected command after options.\n");
@@ -148,7 +152,7 @@ int main(int argc, char **argv)
 	}
 
 	if (nrm_extra_find_allowed_scope(client, "nrm.extra.perf", &scope,
-					 &custom_scope) != 0) {
+	                                 &custom_scope) != 0) {
 		nrm_log_error("Finding scope failed\n");
 		goto cleanup_client;
 	}
@@ -185,7 +189,7 @@ int main(int argc, char **argv)
 
 	if (papi_retval != PAPI_VER_CURRENT) {
 		nrm_log_error("PAPI library init error: %s\n",
-			      PAPI_strerror(papi_retval));
+		              PAPI_strerror(papi_retval));
 		goto cleanup;
 	}
 
@@ -202,7 +206,7 @@ int main(int argc, char **argv)
 	err = PAPI_create_eventset(&EventSet);
 	if (err != PAPI_OK) {
 		nrm_log_error("PAPI eventset creation error: %s\n",
-			      PAPI_strerror(err));
+		              PAPI_strerror(err));
 		goto cleanup;
 	}
 	for (int i = 0; i < EventCodeCnt; i++) {
@@ -210,19 +214,19 @@ int main(int argc, char **argv)
 		err = PAPI_event_name_to_code(EventCodeStrs[i], &EventCode);
 		if (err != PAPI_OK) {
 			nrm_log_error("PAPI event_name translation error: %s\n",
-				      PAPI_strerror(err));
+			              PAPI_strerror(err));
 			goto cleanup;
 		}
 		err = PAPI_add_event(EventSet, EventCode);
 		if (err != PAPI_OK) {
 			nrm_log_error("PAPI eventset append error: %s\n",
-				      PAPI_strerror(err));
+			              PAPI_strerror(err));
 			goto cleanup;
 		}
 
 		nrm_log_debug(
-			      "PAPI code string %s converted to PAPI code %i, and registered.\n",
-			      EventCodeStrs[i], EventCode);
+		        "PAPI code string %s converted to PAPI code %i, and registered.\n",
+		        EventCodeStrs[i], EventCode);
 	}
 
 	int pid = fork();
@@ -233,13 +237,13 @@ int main(int argc, char **argv)
 		/* child, needs to exec the cmd */
 		if (cmpinfo->attach_must_ptrace)
 			if (ptrace(PTRACE_TRACEME, 0, NULL, NULL) == -1) {
-				nrm_log_error("ptrace(PTRACE_TRACEME) failed\n");
+				nrm_log_error(
+				        "ptrace(PTRACE_TRACEME) failed\n");
 				_exit(EXIT_FAILURE);
 			}
 
 		err = execvp(argv[optind], &argv[optind]);
-		nrm_log_error("Error executing command: %s\n",
-			      strerror(errno));
+		nrm_log_error("Error executing command: %s\n", strerror(errno));
 		_exit(EXIT_FAILURE);
 	}
 
@@ -249,15 +253,13 @@ int main(int argc, char **argv)
 
 		/* Wait for the child process to stop on execve(2).  */
 		if (waitpid(pid, &status, 0) == -1) {
-			nrm_log_error("waitpid error: %s\n",
-				      strerror(errno));
+			nrm_log_error("waitpid error: %s\n", strerror(errno));
 			goto cleanup;
 		}
 
-		if (WIFSTOPPED(status) == 0)
-		{
+		if (WIFSTOPPED(status) == 0) {
 			nrm_log_error("Unexpected waitpid status: %d\n",
-				      status);
+			              status);
 			goto cleanup;
 		}
 	}
@@ -317,8 +319,10 @@ int main(int argc, char **argv)
 		nrm_log_debug("NRM time obtained.\n");
 
 		for (int i = 0; i < EventCodeCnt; i++) {
-			if (nrm_client_send_event(client, time, sensors[i], scope, counters[i]) != 0) {
-				nrm_log_error("Sending event to the daemon error\n");
+			if (nrm_client_send_event(client, time, sensors[i],
+			                          scope, counters[i]) != 0) {
+				nrm_log_error(
+				        "Sending event to the daemon error\n");
 				goto cleanup;
 			}
 		}
@@ -328,8 +332,7 @@ int main(int argc, char **argv)
 		int status;
 		err = waitpid(pid, &status, WNOHANG);
 		if (err == -1) {
-			nrm_log_error("waitpid error: %s\n",
-			              strerror(errno));
+			nrm_log_error("waitpid error: %s\n", strerror(errno));
 			goto cleanup;
 		}
 	} while (err != pid);
@@ -340,7 +343,8 @@ int main(int argc, char **argv)
 	PAPI_stop(EventSet, counters);
 	nrm_time_gettime(&time);
 	for (int i = 0; i < EventCodeCnt; i++)
-		nrm_client_send_event(client, time, sensors[i], scope, counters[i]);
+		nrm_client_send_event(client, time, sensors[i], scope,
+		                      counters[i]);
 
 cleanup:
 	free(counters);

--- a/src/perfwrapper/perfwrapper.c
+++ b/src/perfwrapper/perfwrapper.c
@@ -252,7 +252,7 @@ int main(int argc, char **argv)
 			nrm_log_error("waitpid error: %s\n",
 				      strerror(errno));
 			goto cleanup;
-                }
+		}
 
 		if (WIFSTOPPED(status) == 0)
 		{


### PR DESCRIPTION
* Use `ptrace(2)` as appropriate
* Support multiple events
* Stop the child on `execve(2)` so that tracing can be predictably enabled
* Add more elaborate error handling
* Use local variables and preprocessor macros
* Fix the handling of verbose
* Fix the handling of frequency, including error handling
* Minor fixes to `.gitignore` and the configure script