### PR TITLE
Power papi cleanup

### DIFF
--- a/src/power_papi/nrmpower_papi.c
+++ b/src/power_papi/nrmpower_papi.c
@@ -64,15 +64,22 @@ void interrupt(int signum)
 	stop = 1;
 }
 
-bool is_energy_event(char *event_name, uint64_t data_type)
+bool is_energy_event(const char *event_name, uint64_t data_type)
 {
-	return (strstr(event_name, "ENERGY_UJ") &&
+	return (strncmp(event_name, "powercap:::ENERGY_UJ:",
+	                strlen("powercap:::ENERGY_UJ:")) == 0 &&
 	        (data_type == PAPI_DATATYPE_UINT64));
 }
 
-bool is_NUMA_event(char *event_name)
+bool is_name_event(const char *event_name)
 {
-	return (strstr(event_name, "SUBZONE"));
+	return strncmp(event_name,
+	               "powercap:::NAME:", strlen("powercap:::NAME:")) == 0;
+}
+
+bool is_dram_event(const char *event_desc)
+{
+	return strcmp(event_desc, "dram") == 0;
 }
 
 double get_watts(double event_value, int64_t elapsed_time)
@@ -80,14 +87,86 @@ double get_watts(double event_value, int64_t elapsed_time)
 	return ((double)event_value / 1.0e6) / (elapsed_time / 1.0e9);
 }
 
-int parse_numa_id(char *event_name)
+int get_zone_id(const char *event_name)
 {
-	// Extract zone number from each of the following:
+	// Extract zone (not subzone) number from event names such as:
 	// powercap:::ENERGY_UJ:ZONE0
 	// powercap:::ENERGY_UJ:ZONE0_SUBZONE0
-	char str_numa_id;
-	str_numa_id = event_name[25];
-	return str_numa_id - '0'; // ??? converts numa_id to integer ???
+	// powercap:::NAME:ZONE0
+	const char *zone;
+	zone = strstr(event_name, ":ZONE");
+	assert(zone);
+	return strtol(zone + strlen(":ZONE"), NULL, 10);
+}
+
+int get_subzone_id(const char *event_name)
+{
+	// Extract optional subzone number from event names such as:
+	// powercap:::ENERGY_UJ:ZONE0_SUBZONE0
+	// powercap:::NAME:ZONE0_SUBZONE0
+	// If none found, return -1.
+	const char *subzone;
+	if ((subzone = strstr(event_name, "_SUBZONE")) != NULL)
+		return strtol(subzone + strlen("_SUBZONE"), NULL, 10);
+	else
+		return -1;
+}
+
+int get_zone_name_id(
+        int zone_id,
+        const char EventNames[MAX_powercap_EVENTS][PAPI_MAX_STR_LEN],
+        int num_events)
+{
+	// Look for the index of the NAME event for the zone (not the subzone).
+	for (int i = 0; i < num_events; i++)
+		if (is_name_event(EventNames[i]) &&
+		    get_zone_id(EventNames[i]) == zone_id &&
+		    get_subzone_id(EventNames[i]) == -1)
+			return i;
+
+	return -1;
+}
+
+int get_package_id(char *event_name,
+                   const char EventNames[MAX_powercap_EVENTS][PAPI_MAX_STR_LEN],
+                   char *const EventDescs[MAX_powercap_EVENTS],
+                   int num_events,
+                   const char **desc)
+{
+	// Zone IDs and package IDs need not be the same, e.g.,
+	// /sys/class/powercap/intel-rapl:2/name may be "package-1", and PAPI
+	// inherits that from RAPL.
+	int zone_id = get_zone_id(event_name);
+	// Get the index of the name event for this zone, which will contain
+	// the package name in the description.
+	int zone_name_id = get_zone_name_id(zone_id, EventNames, num_events);
+	assert(zone_name_id != -1);
+	if (desc)
+		*desc = EventDescs[zone_name_id];
+	if (strncmp(EventDescs[zone_name_id], "package-", strlen("package-")) ==
+	    0)
+		return strtol(EventDescs[zone_name_id] + strlen("package-"),
+		              NULL, 10);
+	else
+		return -1;
+}
+
+const char *
+get_subzone_desc(char *event_name,
+                 const char EventNames[MAX_powercap_EVENTS][PAPI_MAX_STR_LEN],
+                 char *const EventDescs[MAX_powercap_EVENTS],
+                 int num_events)
+{
+	int zone_id = get_zone_id(event_name);
+	int subzone_id = get_subzone_id(event_name);
+	if (subzone_id == -1)
+		return NULL;
+	for (int i = 0; i < num_events; i++)
+		if (is_name_event(EventNames[i]) &&
+		    get_zone_id(EventNames[i]) == zone_id &&
+		    get_subzone_id(EventNames[i]) == subzone_id)
+			return EventDescs[i];
+	assert(0);
 }
 
 int get_cpu_idx(hwloc_topology_t topology, int cpu)
@@ -197,6 +276,8 @@ int main(int argc, char **argv)
 	                                                        // loop
 	int DataTypes[MAX_powercap_EVENTS]; // For datatype checking in
 	                                    // measurement loop
+	char *EventDescs[MAX_powercap_EVENTS];
+	int NumaIDs[MAX_powercap_EVENTS];
 	PAPI_event_info_t EventInfo;
 
 	papi_retval = PAPI_enum_cmp_event(&EventCode, PAPI_ENUM_FIRST,
@@ -208,8 +289,17 @@ int main(int argc, char **argv)
 		nrm_log_debug("code: %d, event: %s\n", EventCode,
 		              EventNames[num_events]);
 		assert(PAPI_get_event_info(EventCode, &EventInfo) == PAPI_OK);
+		assert(num_events < MAX_powercap_EVENTS);
 		DataTypes[num_events] = EventInfo.data_type;
-		assert(PAPI_add_event(EventSet, EventCode) == PAPI_OK);
+		if (strlen(EventInfo.long_descr) > 0) {
+			if (EventInfo.long_descr[strlen(EventInfo.long_descr) -
+			                         1] == '\n')
+				EventInfo.long_descr
+				        [strlen(EventInfo.long_descr) - 1] =
+				        '\0';
+			EventDescs[num_events] = strdup(EventInfo.long_descr);
+		} else
+			EventDescs[num_events] = NULL;
 
 		num_events++;
 		papi_retval = PAPI_enum_cmp_event(&EventCode, PAPI_ENUM_EVENTS,
@@ -220,12 +310,13 @@ int main(int argc, char **argv)
 	hwloc_obj_t numanode;
 	hwloc_cpuset_t cpus;
 
-	nrm_scope_t *nrm_cpu_scopes[MAX_MEASUREMENTS],
-	        *nrm_numa_scopes[MAX_MEASUREMENTS],
-	        *custom_scopes[MAX_MEASUREMENTS];
+	// These arrays are indexed by energy event id [0..n_energy_events-1].
+	nrm_scope_t *nrm_scopes[MAX_MEASUREMENTS];
+	bool nrm_scopes_free[MAX_MEASUREMENTS];
+	const char *nrm_event_names[MAX_MEASUREMENTS];
 
 	int n_energy_events = 0, n_scopes = 0, n_numa_scopes = 0,
-	    n_cpu_scopes = 0, n_custom_scopes = 0, cpu_idx, cpu, numa_id;
+	    n_cpu_scopes = 0, cpu_idx, cpu, numa_id;
 	char *event;
 	char *scope_name;
 
@@ -242,26 +333,50 @@ int main(int argc, char **argv)
 		// need to create custom scope name first out of available
 		// information, then scope
 		if (is_energy_event(event, DataTypes[i])) {
-			n_energy_events++;
-			numa_id = parse_numa_id(event); // should match
-			                                // NUMANODE's logical ID
-			nrm_log_debug("energy event detected.\n",
-			              n_energy_events);
+			const char *zone_desc;
 
-			if (is_NUMA_event(event)) {
-				err = nrm_extra_create_name_ssu("nrm.papi",
-				                                "numa", numa_id,
-				                                &scope_name);
-				nrm_log_debug("Creating new scope: %s\n",
-				              scope_name);
+			nrm_log_debug("energy event detected %s\n", event);
 
-				scope = nrm_scope_create(scope_name);
-				nrm_scope_add(scope, NRM_SCOPE_TYPE_NUMA,
-				              numa_id);
-				nrm_extra_find_scope(client, &scope, &added);
-				free(scope_name);
-				nrm_numa_scopes[numa_id] = scope;
-				n_numa_scopes++;
+			if ((numa_id = get_package_id(event, EventNames,
+			                              EventDescs, num_events,
+			                              &zone_desc)) == -1) {
+				nrm_log_debug(
+				        "skipping; not part of a package\n (%s)",
+				        zone_desc);
+				continue;
+			}
+
+			const char *subzone_desc = get_subzone_desc(
+			        event, EventNames, EventDescs, num_events);
+
+			if (subzone_desc != NULL) {
+				if (is_dram_event(subzone_desc)) {
+					err = nrm_extra_create_name_ssu(
+					        "nrm.papi", "numa", numa_id,
+					        &scope_name);
+					nrm_log_debug(
+					        "Creating new scope: %s\n",
+					        scope_name);
+
+					scope = nrm_scope_create(scope_name);
+					nrm_scope_add(scope,
+					              NRM_SCOPE_TYPE_NUMA,
+					              numa_id);
+					nrm_extra_find_scope(client, &scope,
+					                     &added);
+					free(scope_name);
+
+					n_numa_scopes++;
+
+					nrm_log_debug(
+					        "adding NUMA event (%s/%s)\n",
+					        zone_desc, subzone_desc);
+				} else {
+					nrm_log_debug(
+					        "skipping; not a NUMA event (%s/%s)\n",
+					        zone_desc, subzone_desc);
+					continue;
+				}
 			} else { // need NUMANODE object to parse CPU
 				 // indexes
 				err = nrm_extra_create_name_ssu("nrm.papi",
@@ -275,37 +390,45 @@ int main(int argc, char **argv)
 				        topology, HWLOC_OBJ_NUMANODE, numa_id);
 				cpus = numanode->cpuset;
 				hwloc_bitmap_foreach_begin(cpu, cpus)
-				        cpu_idx = get_cpu_idx(topology, cpu);
-				nrm_scope_add(scope, NRM_SCOPE_TYPE_CPU,
-				              cpu_idx);
+				{
+					cpu_idx = get_cpu_idx(topology, cpu);
+					nrm_scope_add(scope, NRM_SCOPE_TYPE_CPU,
+					              cpu_idx);
+				}
 				hwloc_bitmap_foreach_end();
 				nrm_extra_find_scope(client, &scope, &added);
 				free(scope_name);
-				nrm_cpu_scopes[numa_id] = scope;
+
 				n_cpu_scopes++;
+
+				nrm_log_debug("adding CPU event (%s)\n",
+				              zone_desc);
 			}
-			if (added) {
-				custom_scopes[numa_id] = scope;
-				n_custom_scopes++;
-			}
-			n_scopes++;
+
+			nrm_scopes[n_energy_events] = scope;
+			nrm_scopes_free[n_energy_events] = added;
+			nrm_event_names[n_energy_events] = event;
+			n_energy_events++;
+			if (added)
+				n_scopes++;
+
+			assert(PAPI_add_named_event(EventSet, event) ==
+			       PAPI_OK);
 		}
 	}
 
-	nrm_log_debug("%d candidate energy events detected.\n",
-	              n_energy_events);
-	nrm_log_debug(
-	        "%d NRM scopes initialized (%d NUMA, %d CPU, %d custom)\n",
-	        n_scopes, n_numa_scopes, n_cpu_scopes, n_custom_scopes);
+	nrm_log_debug("%d relevant energy events detected.\n", n_energy_events);
+	nrm_log_debug("NRM scopes initialized: %d NUMA, %d CPU (%d new)\n",
+	              n_numa_scopes, n_cpu_scopes, n_scopes);
 
 	long long *event_values;
 	nrm_time_t last_time, current_time;
 	int64_t elapsed_time;
 	double watts_value, *event_totals;
 
-	event_values = calloc(num_events, sizeof(long long));
-	event_totals = calloc(num_events, sizeof(double)); // converting then
-	                                                   // storing
+	event_values = calloc(n_energy_events, sizeof(long long));
+	event_totals = calloc(n_energy_events, sizeof(double)); // converting
+	                                                        // then storing
 
 	nrm_time_gettime(&last_time);
 
@@ -334,33 +457,21 @@ int main(int argc, char **argv)
 		elapsed_time = nrm_time_diff(&last_time, &current_time);
 
 		nrm_log_debug("scaled energy measurements:\n");
-		for (i = 0; i < num_events; i++) {
-			event = EventNames[i];
+		for (i = 0; i < n_energy_events; i++) {
+			watts_value = get_watts(event_values[i] -
+			                                event_totals[i] * 1e6,
+			                        elapsed_time);
+			event_totals[i] = event_values[i] / 1e6;
 
-			if (is_energy_event(event, DataTypes[i])) {
-				watts_value = get_watts(
-				        event_values[i] - event_totals[i] * 1e6,
-				        elapsed_time);
-				numa_id = parse_numa_id(event); // should match
-				                                // NUMANODE's
-				                                // logical ID
+			nrm_log_debug("%-45s%4f J (avg. power %f W)\n",
+			              nrm_event_names[i], event_totals[i],
+			              watts_value);
 
-				event_totals[i] = event_values[i] / 1e6;
+			scope = nrm_scopes[i];
 
-				if (is_NUMA_event(event)) {
-					scope = nrm_numa_scopes[numa_id];
-				} else {
-					scope = nrm_cpu_scopes[numa_id];
-				}
-				nrm_log_debug("%-45s%4f J (avg. power %f W)\n",
-				              EventNames[i], event_totals[i],
-				              watts_value);
-
-				err = nrm_client_send_event(client,
-				                            current_time,
-				                            sensor, scope,
-				                            event_totals[i]);
-			}
+			err = nrm_client_send_event(client, current_time,
+			                            sensor, scope,
+			                            event_totals[i]);
 		}
 		if (err == -1 || errno == EINTR) {
 			nrm_log_error("Interrupted. Exiting\n");
@@ -378,39 +489,25 @@ int main(int argc, char **argv)
 		nrm_time_gettime(&current_time);
 
 		/* final send here */
-		for (i = 0; i < num_events; i++) {
-			event = EventNames[i];
+		for (i = 0; i < n_energy_events; i++) {
+			event_totals[i] = event_values[i] / 1e6;
 
-			if (is_energy_event(event, DataTypes[i])) {
-				numa_id = parse_numa_id(event); // should match
-				                                // NUMANODE's
-				                                // logical ID
+			scope = nrm_scopes[i];
 
-				event_totals[i] = event_values[i] / 1e6;
-
-				if (is_NUMA_event(event)) {
-					scope = nrm_numa_scopes[numa_id];
-				} else {
-					scope = nrm_cpu_scopes[numa_id];
-				}
-				nrm_client_send_event(client, current_time,
-				                      sensor, scope,
-				                      event_totals[i]);
-			}
+			nrm_client_send_event(client, current_time, sensor,
+			                      scope, event_totals[i]);
 		}
 	}
 
-	for (i = 0; i < n_custom_scopes; i++) {
-		nrm_client_remove_scope(client, custom_scopes[i]);
-	}
-	for (i = 0; i < n_cpu_scopes; i++) {
-		nrm_scope_destroy(nrm_cpu_scopes[i]);
-	}
-
-	for (i = 0; i < n_numa_scopes; i++) {
-		nrm_scope_destroy(nrm_numa_scopes[i]);
-	}
+	for (i = 0; i < n_scopes; i++)
+		if (nrm_scopes_free[i]) {
+			nrm_client_remove_scope(client, nrm_scopes[i]);
+			nrm_scope_destroy(nrm_scopes[i]);
+		}
 	nrm_log_debug("NRM scopes deleted.\n");
+
+	for (i = 0; i < num_events; i++)
+		free(EventDescs[i]);
 
 	nrm_sensor_destroy(&sensor);
 	nrm_client_destroy(&client);

--- a/src/power_papi/nrmpower_papi.c
+++ b/src/power_papi/nrmpower_papi.c
@@ -471,11 +471,10 @@ int main(int argc, char **argv)
 
 			scope = nrm_scopes[i];
 
-			if (nrm_client_send_event(client, current_time,
-			                          sensor, scope,
-			                          event_totals[i])) {
-			    stop = 1;
-			    break;
+			if (nrm_client_send_event(client, current_time, sensor,
+			                          scope, event_totals[i])) {
+				stop = 1;
+				break;
 			}
 		}
 

--- a/src/power_papi/nrmpower_papi.c
+++ b/src/power_papi/nrmpower_papi.c
@@ -338,8 +338,9 @@ int main(int argc, char **argv)
 			event = EventNames[i];
 
 			if (is_energy_event(event, DataTypes[i])) {
-				watts_value = get_watts(event_values[i] - event_totals[i] * 1e6,
-				                        elapsed_time);
+				watts_value = get_watts(
+				        event_values[i] - event_totals[i] * 1e6,
+				        elapsed_time);
 				numa_id = parse_numa_id(event); // should match
 				                                // NUMANODE's
 				                                // logical ID
@@ -351,12 +352,12 @@ int main(int argc, char **argv)
 				} else {
 					scope = nrm_cpu_scopes[numa_id];
 				}
-				nrm_log_debug(
-				        "%-45s%4f J (avg. power %f W)\n",
-				        EventNames[i], event_totals[i],
-				        watts_value);
+				nrm_log_debug("%-45s%4f J (avg. power %f W)\n",
+				              EventNames[i], event_totals[i],
+				              watts_value);
 
-				err = nrm_client_send_event(client, current_time,
+				err = nrm_client_send_event(client,
+				                            current_time,
 				                            sensor, scope,
 				                            event_totals[i]);
 			}
@@ -382,7 +383,8 @@ int main(int argc, char **argv)
 
 			if (is_energy_event(event, DataTypes[i])) {
 				numa_id = parse_numa_id(event); // should match
-				                                // NUMANODE's logical ID
+				                                // NUMANODE's
+				                                // logical ID
 
 				event_totals[i] = event_values[i] / 1e6;
 
@@ -391,7 +393,8 @@ int main(int argc, char **argv)
 				} else {
 					scope = nrm_cpu_scopes[numa_id];
 				}
-				nrm_client_send_event(client, current_time, sensor, scope,
+				nrm_client_send_event(client, current_time,
+				                      sensor, scope,
 				                      event_totals[i]);
 			}
 		}

--- a/src/power_papi/nrmpower_papi.c
+++ b/src/power_papi/nrmpower_papi.c
@@ -298,6 +298,7 @@ int main(int argc, char **argv)
 				        [strlen(EventInfo.long_descr) - 1] =
 				        '\0';
 			EventDescs[num_events] = strdup(EventInfo.long_descr);
+			nrm_log_debug("long_descr %s\n", EventInfo.long_descr);
 		} else
 			EventDescs[num_events] = NULL;
 
@@ -341,7 +342,7 @@ int main(int argc, char **argv)
 			                              EventDescs, num_events,
 			                              &zone_desc)) == -1) {
 				nrm_log_debug(
-				        "skipping; not part of a package\n (%s)",
+				        "skipping; not part of a package (%s)\n",
 				        zone_desc);
 				continue;
 			}


### PR DESCRIPTION
* Remove the assumption that PAPI zone ids are equal to socket ids (it currently holds with PAPI, but not with the underlying Linux powercap infrastructure).
* Clean up cmdline handling a bit.
* Clean up interrupt handling a bit (still messed up due to handling in the dependencies).
* Only query the energy counters, not all the PAPI powercap events.
* Use `PAPI_read` rather than `PAPI_stop`/`PAPI_start`.
* Fix the sleep period calculation.